### PR TITLE
add `docs` to list of valid blocks for collection settings

### DIFF
--- a/shared/languageUtils/collectionSettingsFiles/getValidBlockNames.ts
+++ b/shared/languageUtils/collectionSettingsFiles/getValidBlockNames.ts
@@ -16,5 +16,6 @@ export function getValidBlockNames(): string[] {
         RequestFileBlockName.PreRequestScript,
         RequestFileBlockName.PostResponseScript,
         RequestFileBlockName.Tests,
+        RequestFileBlockName.Docs,
     ];
 }


### PR DESCRIPTION
Fixes #184 